### PR TITLE
Added DockerClient and Payloads mixin

### DIFF
--- a/cur.gemspec
+++ b/cur.gemspec
@@ -27,6 +27,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "net_http_unix", "0.2.1"
+
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"

--- a/lib/cur.rb
+++ b/lib/cur.rb
@@ -1,5 +1,7 @@
 require "cur/version"
 require "cur/container_definition"
+require "cur/payloads"
+require "cur/docker_client"
 
 module Cur
   # Your code goes here...

--- a/lib/cur/docker_client.rb
+++ b/lib/cur/docker_client.rb
@@ -1,0 +1,179 @@
+require 'json'
+require 'logger'
+require 'net_http_unix'
+require 'pp'
+require_relative 'payloads'
+
+module Cur
+  # Client for interfacing with the docker API.  API v1.21 (docker version 1.9.x) is used
+  # by default.
+  #
+  # See https://docs.docker.com/engine/reference/api/docker_remote_api_v1.21/
+  class DockerClient
+    include Payloads
+
+    Endpoint = Struct.new(:method, :path, :valid_responses)
+
+    API = {
+      :create_image => Endpoint.new(:Post, "/images/create", ["200"]),
+      :list_images => Endpoint.new(:Get, "/images/json", ["200"]),
+      :inspect_image => Endpoint.new(:Get, "/images/%s/json", ["200"]),
+      :delete_image => Endpoint.new(:Delete, "/images/%s", ["200"]),
+      :create_container => Endpoint.new(:Post, "/containers/create", ["201"]),
+      :list_containers => Endpoint.new(:Get, "/containers/json", ["200"]),
+      :inspect_container => Endpoint.new(:Get, "/containers/%s/json", ["200"]),
+      :start_container => Endpoint.new(:Post, "/containers/%s/start", ["204"]),
+      :attach_container => Endpoint.new(:Post, "/containers/%s/attach", ["200"]),
+      :wait_container => Endpoint.new(:Post, "/containers/%s/wait", ["200"]),
+      :stop_container => Endpoint.new(:Post, "/containers/%s/stop", ["204", "304"]),
+      :container_logs => Endpoint.new(:Get, "/containers/%s/logs", ["200"]),
+      :kill_container => Endpoint.new(:Post, "/containers/%s/kill", ["204"]),
+      :delete_container => Endpoint.new(:Delete, "/containers/%s", ["204"])
+    }
+
+    class APIError < StandardError
+      attr_reader :code
+
+      def initialize(code, message)
+        super("#{code}: #{message}")
+        @code = code
+      end
+    end
+
+    attr_reader :api_version, :protocol, :location, :port, :logger
+
+    def initialize(opts={})
+      @api_version = opts[:api_version] || 'v1.21'
+      @protocol = opts[:protocol] || 'unix'
+      @location = opts[:location] || '/var/run/docker.sock'
+      @port = opts[:port]
+      @logger = Logger.new(opts[:log_path] || STDOUT)
+    end
+
+    def ping
+      request_and_response(:list_containers)
+      true
+    rescue => e
+      false
+    end
+
+    def pull_image(image=None, tag='latest')
+      params = {fromImage: image, tag: tag}
+      multi_json_to_dto(request_and_response(:create_image, params: params))
+    end
+
+    def list_images(all=true)
+      json_to_dto(request_and_response(:list_images, params: {all: all}))
+    end
+
+    def inspect_image(image=None)
+      json_to_dto(request_and_response(:inspect_image, id: image))
+    end
+
+    def delete_image(image=None, force=false)
+      json_to_dto(request_and_response(:delete_image, id: image, params: {force: force}))
+    end
+
+    def create_container(payload)
+      json_to_dto(request_and_response(:create_container, payload: payload))
+    end
+
+    def delete_container(id=nil, force=false)
+      request_and_response(:delete_container, id: id, params: {force: force})
+      true
+    end
+
+    def list_containers(all=true)
+      json_to_dto(request_and_response(:list_containers, params: {all: all}))
+    end
+
+    def inspect_container(id=nil)
+      json_to_dto(request_and_response(:inspect_container, id: id))
+    end
+
+    def start_container(id=nil)
+      request_and_response(:start_container, id: id)
+      true
+    end
+
+    def attach_container(id=nil, logs=true, stream=false, stdin=false, stdout=true, stderr=true)
+      params = {
+        logs: logs,
+        stream: stream,
+        stdin: stdin,
+        stdout: stdout,
+        stderr: stderr
+      }
+      OpenStruct.new Stream: request_and_response(:attach_container, id: id, params: params)
+    end
+
+    def container_logs(id=nil, follow=false, stdout=true, stderr=true, since=0, timestamps=true, tail='all')
+      params = {
+        follow: follow,
+        stdout: stdout,
+        stderr: stderr,
+        since: since,
+        timestamps: timestamps,
+        tail: tail
+      }
+      OpenStruct.new Stream: request_and_response(:container_logs, id: id, params: params)
+    end
+
+    def wait_container(id=nil)
+      json_to_dto(request_and_response(:wait_container, id: id))
+    end
+
+    def stop_container(id=nil, t=5)
+      request_and_response(:stop_container, id: id, params: {t: t})
+      true
+    end
+
+    def kill_container(id=nil, signal='SIGINT')
+      request_and_response(:kill_container, id: id, params: {signal: signal})
+      true
+    end
+
+    def address
+      @address ||= "#{@protocol}://#{@location}"
+    end
+
+    private
+
+    def request_and_response(endpoint_key, details={})
+      endpoint = DockerClient::API[endpoint_key]
+      request = build(endpoint, details)
+      logger.info("#{request.method} #{request.path}")
+      if details[:payload]
+        logger.info("#{JSON.pretty_generate(details[:payload])}")
+        request.body = JSON.dump(details[:payload])
+      end
+      response = http_client.request(request)
+      unless endpoint.valid_responses.include? response.code
+        raise APIError.new(response.code, response.body)
+      end
+      response.body
+    end
+
+    def build(endpoint, details={})
+      url = url(endpoint, details)
+      klass = Net::HTTP.const_get(endpoint.method)
+      klass.new(url, initheader = default_headers)
+    end
+
+    def default_headers
+      {'Content-Type' => 'application/json'}
+    end
+
+    def url(endpoint, details={})
+      result = "/#{api_version}#{endpoint.path}" % details[:id]
+      if details[:params]
+        result += "?#{URI.encode_www_form(details[:params])}"
+      end
+      result
+    end
+
+    def http_client
+      @http_client ||= NetX::HTTPUnix.new(address, port)
+    end
+  end
+end

--- a/lib/cur/payloads.rb
+++ b/lib/cur/payloads.rb
@@ -1,0 +1,66 @@
+require 'json'
+require 'ostruct'
+require 'stringio'
+
+module Cur
+  module Payloads
+    def json_to_dto(json)
+      doc_to_dto(JSON.parse(json))
+    end
+
+    def multi_json_to_dto(json)
+      # dirty deeds, done dirt cheap
+      StringIO.new(json).readlines.map(&:strip)
+                                  .map(&split_objs)
+                                  .flatten
+                                  .map(&massage_lines)
+                                  .compact
+                                  .map(&to_dtos)
+    end
+
+    def dto_to_json(dto)
+      JSON.dump(dto_to_doc(dto))
+    end
+
+    def doc_to_dto(doc)
+      if doc.kind_of? Array
+        doc.map{|e| doc_to_dto(e)}
+      elsif doc.kind_of? Hash
+        dto = OpenStruct.new(doc)
+        doc.each do |k, v|
+          dto.send("#{k}=", doc_to_dto(v)) if v.kind_of? Hash
+        end
+        dto
+      else
+        doc
+      end
+    end
+
+    def dto_to_doc(dto)
+      doc = Hash.new
+      attrs = (dto.methods - OpenStruct.instance_methods).reject{|m| m.to_s.match /\=/}
+      attrs.each do |attr|
+        doc[attr] = dto.send(attr)
+        doc[attr] = dto_to_doc(doc[attr]) if doc[attr].kind_of? OpenStruct
+      end
+      doc
+    end
+
+    private 
+
+    def to_dtos
+      lambda {|line| json_to_dto(line)}
+    end
+
+    def split_objs
+      lambda {|line| line.split("}{")}
+    end
+
+    def massage_lines
+      lambda do |line|
+        line = "{#{line}" unless line.match /^{/
+        line = "#{line}}" unless line.match /}[\n]?$/
+      end
+    end
+  end
+end

--- a/spec/docker_client_spec.rb
+++ b/spec/docker_client_spec.rb
@@ -1,0 +1,125 @@
+require_relative 'spec_helper'
+
+module Cur
+  describe DockerClient do
+    # switch to STDOUT if needing to debug
+    let(:log_path) { '/dev/null' }
+
+    describe "#address" do
+      it "should default to standard docker unix domain socket" do
+        client = DockerClient.new
+        expect(client.address).to eq("unix:///var/run/docker.sock")
+      end
+
+      it "should allow overriding of the protocol when the client is constructed" do
+        client = DockerClient.new :protocol => 'http'
+        expect(client.address).to eq("http:///var/run/docker.sock")
+      end
+
+      it "should allow overriding of the location when the client is constructed" do
+        client = DockerClient.new :location => '127.0.0.1'
+        expect(client.address).to eq("unix://127.0.0.1")
+      end
+    end
+
+    describe "image operations" do
+      let(:client) { DockerClient.new log_path: log_path }
+
+      before { client.delete_image(image='busybox', force=true) rescue nil }
+
+      it "should allow images to be pulled, listed, inspected and removed" do
+        client.pull_image(image='busybox')
+
+        image_tags = client.list_images.map(&:RepoTags).flatten
+        expect(image_tags.include?("busybox:latest")).to be true
+
+        busybox = client.inspect_image(image='busybox')
+        expect(busybox.Id).to_not be_nil
+
+        untagged = client.delete_image(image='busybox', force=true)
+                         .detect{|delete| delete.Untagged}
+                         .Untagged
+        expect(untagged).to eq("busybox:latest")
+      end
+    end
+
+    describe "#ping" do
+      let(:client) { DockerClient.new log_path: log_path }
+
+      it "should return true if it can connect to the docker daemon" do
+        expect(client.ping).to be true
+      end
+
+      it "should return false if it cannot connect to the docker daemon" do
+        expect(DockerClient.new(:protocol => 'http').ping).to be false
+      end
+    end
+
+    describe "container operations" do
+      let(:client) { DockerClient.new log_path: log_path }
+      let(:container_def) do
+        {
+          Image: 'busybox',
+          Hostname: 'curtest',
+          Cmd: ['/bin/hostname'],
+          Tty: true,
+          AttachStdin: true,
+          AttachStderr: true,
+          Labels: {
+            curtest: "true"
+          },
+        }
+      end
+
+      before do
+        client.pull_image(image='busybox')
+        client.list_containers.select{|c| c.Labels && c.Labels.curtest}.each do |container|
+          client.delete_container(id=container.id, force=true) rescue nil
+        end
+      end
+
+      it "should allow containers to be created, listed, inspected and deleted" do
+        container = client.create_container(container_def)
+        expect(container.Id).to_not be_empty
+
+        container_meta = client.list_containers.detect{|c| c.Labels.curtest}
+        expect(container_meta).to_not be_nil
+
+        container = client.inspect_container(id=container.Id)
+        expect(container).to_not be_nil
+
+        client.delete_container(id=container.Id, force=true)
+        expect{client.inspect_container(id=container.Id)}.to raise_error(DockerClient::APIError)
+      end
+
+      it "should allow for containers to be started, attached to and waited upon" do
+        container = client.create_container(container_def)
+        expect(client.start_container(id=container.Id)).to be true
+        sleep(0.1)
+        expect(client.attach_container(id=container.Id).Stream.strip).to eq("curtest")
+        expect(client.wait_container(id=container.Id).StatusCode).to eq(0)
+        expect(client.container_logs(id=container.Id).Stream).to_not be_empty
+      end
+
+      describe "long-running containers" do
+        let!(:container) do
+          client.create_container(container_def).tap do |container|
+            client.start_container(id=container.Id)
+          end
+        end
+
+        it "should allow for containers to be stopped" do
+          expect(client.stop_container(container.Id)).to be true
+          container_details = client.inspect_container(container.Id)
+          expect(container_details.State.Running).to be false
+        end
+
+        it "should allow for containers to be killed" do
+          expect(client.kill_container(container.Id, signal='SIGKILL')).to be true
+          container_details = client.inspect_container(container.Id)
+          expect(container_details.State.Running).to be false
+        end
+      end
+    end
+  end
+end

--- a/spec/payloads_spec.rb
+++ b/spec/payloads_spec.rb
@@ -1,0 +1,89 @@
+require_relative 'spec_helper'
+
+module Cur
+  describe Payloads do
+    let (:dependent) { Object.new.extend Payloads }
+
+    let(:json) do
+      <<-JSON
+        {
+          "scalar": "scalar",
+          "array": [1, 2, 3],
+          "nested": {
+            "nested_scalar": "nested_scalar",
+            "nested_array": [10, 11, 12]
+          }
+        }
+      JSON
+    end
+
+    let(:multi_json) do
+      <<-JSON
+        {"status": "Pulling..."}
+        {"status": "Pulling..."}
+      JSON
+    end
+
+    let(:json_array) { "[1, 2, 3]" }
+
+    let (:doc) do
+      {
+        scalar: "scalar",
+        array: [1, 2, 3],
+        nested: {
+          nested_scalar: "nested_scalar",
+          nested_array: [10, 11, 12]
+        }
+      }
+    end
+
+    let (:dto) do
+      OpenStruct.new.tap do |dto|
+        dto.scalar = "scalar"
+        dto.array = [1, 2, 3]
+        dto.nested = OpenStruct.new({
+          nested_scalar: "nested_scalar",
+          nested_array: [10, 11, 12]
+        })
+      end
+    end
+
+    describe "#json_to_dto" do
+      it "should convert json to a DTO object" do
+        expect(dependent.json_to_dto(json)).to eq(dto)
+      end
+
+      it "should handle json arrays at top level" do
+        expect(dependent.json_to_dto(json_array)).to eq([1, 2, 3])
+      end
+    end
+
+    describe "#multi_json_to_dto" do
+      it "should convert multi json objects to an array of DTO objects" do
+        dtos = dependent.multi_json_to_dto(multi_json)
+        expect(dtos.size).to eq(2)
+        dtos.each do |dto|
+          expect(dto.status).to eq("Pulling...")
+        end
+      end
+    end
+
+    describe "#dto_to_json" do
+      it "should convert DTO object to json" do
+        expect(JSON.parse(dependent.dto_to_json(dto))).to eq(JSON.parse(json))
+      end
+    end
+
+    describe "#doc_to_dto" do
+      it "should convert hash document to DTO object" do
+        expect(dependent.doc_to_dto(doc)).to eq(dto)
+      end
+    end
+
+    describe "#dto_to_doc" do
+      it "should convert DTO object to hash doc" do
+        expect(dependent.dto_to_doc(dto)).to eq(doc)
+      end
+    end
+  end
+end


### PR DESCRIPTION
```DockerClient``` exposes a subset of the docker API as described by
https://docs.docker.com/engine/reference/api/docker_remote_api_v1.21/
JSON results are marshalled to ```OpenStruct``` DTOs by the methods in the
```Payloads``` mixin.

Editorial choice made to not modify the payload attribute names to
be rubyish.  This means attributes like "ImageID" are accessed in
the DTOs via ```dto.ImageID``` and not ```dto.image_id```.  While this deviates
from ruby semantics a bit, it mirrors the docker API documentation
which will have API results described as:

```
{
  "ImageID: "asdasid930ekad9013easd"
}
```

I would rather not have the cognitive overhead of translating the
documented API atttributes to something rubyish and vice versa
from here to eternity.